### PR TITLE
fix(publish): set the private to false and config the registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honojs/graphql-server",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "repository": "git@github.com:honojs/grahql-server.git",
   "author": "Minghe Huang <h.minghe@gmail.com>",
   "main": "dist/index.js",
@@ -9,6 +9,11 @@
     "dist"
   ],
   "license": "MIT",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "test": "jest",
     "test:deno": "deno test deno_test",


### PR DESCRIPTION
This MR is to fix the publish failure issue for previous run.
```
Error: Unable to publish @honojs/graphql-server v0.0.1 to NPM. 
npm publish exited with a status of 1.
    at Object.publish (/home/runner/work/_actions/JS-DevTools/npm-publish/v1/src/npm.ts:112:13)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

ProcessError: npm publish exited with a status of 1.
    at normalizeResult (/home/runner/work/_actions/JS-DevTools/npm-publish/v1/node_modules/@jsdevtools/ez-spawn/lib/normalize-result.js:31:1)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/JS-DevTools/npm-publish/v1/node_modules/@jsdevtools/ez-spawn/lib/async.js:79:1)
    at ChildProcess.emit (events.js:314:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:276:12)
```

I just tested it locally, it fixed. and now it's on npmjs.org with version 0.0.2.

```
➜  graphql-server git:(production) ✗ yarn publish
yarn publish v1.22.17
[1/4] Bumping version...
info Current version: 0.0.2
question New version:
[2/4] Logging in...
[3/4] Publishing...
success Published.
[4/4] Revoking token...
info Not revoking login token, specified via config file.
✨  Done in 5.88s.
```

FYI: https://github.com/lerna/lerna/issues/1821 